### PR TITLE
Support for libcamera on RPi

### DIFF
--- a/build_scripts/build-packages.sh
+++ b/build_scripts/build-packages.sh
@@ -157,7 +157,7 @@ for pkg in $PACKAGES; do
 
     PACKAGE_DEPS="gnupg, ros-$ROS_DISTRO-ros-core, ros-$ROS_DISTRO-image-transport, ros-$ROS_DISTRO-compressed-image-transport, ros-$ROS_DISTRO-pybind11-vendor, ros-$ROS_DISTRO-cv-bridge"
     if [ "$ROS_DISTRO" == "humble" ]; then
-        PACKAGE_DEPS="$PACKAGE_DEPS, ros-$ROS_DISTRO-rplidar-ros, ros-$ROS_DISTRO-web-video-server, ros-$ROS_DISTRO-rosbag2, ros-$ROS_DISTRO-rosbag2-py, ros-$ROS_DISTRO-rosbag2-storage-mcap"
+        PACKAGE_DEPS="$PACKAGE_DEPS, ros-$ROS_DISTRO-rplidar-ros, ros-$ROS_DISTRO-camera-ros, ros-$ROS_DISTRO-web-video-server, ros-$ROS_DISTRO-rosbag2, ros-$ROS_DISTRO-rosbag2-py, ros-$ROS_DISTRO-rosbag2-storage-mcap"
     fi
 
     if [ "$pkg" == "aws-deepracer-core" ]; then

--- a/build_scripts/build-prerequisites-humble.sh
+++ b/build_scripts/build-prerequisites-humble.sh
@@ -60,7 +60,7 @@ sudo apt -y update && sudo apt install -y \
     ros-humble-ros-base \
     ros-humble-test-msgs
 
-sudo pip3 install -U "setuptools==58.2.0" pip catkin_pkg "Cython<3"
+sudo pip3 install -U "setuptools==58.2.0" pip catkin_pkg "Cython==0.29.28"
 
 # Builds and installs OpenVINO
 # $DIR/build_scripts/build-openvino.sh

--- a/build_scripts/files/common/start_ros.sh
+++ b/build_scripts/files/common/start_ros.sh
@@ -37,8 +37,10 @@ fi
 
 if [ -f /sys/firmware/devicetree/base/model ] && grep -q "Raspberry Pi" /sys/firmware/devicetree/base/model; then
     BATTERY_DUMMY='battery_dummy:=True'
+    CAMERA_MODE='camera_mode:=modern'
 else
     BATTERY_DUMMY=''
+    CAMERA_MODE=''
 fi
 
 if [ -f /opt/aws/deepracer/logging.conf ]; then
@@ -49,4 +51,4 @@ else
     LOGGING_PROVIDER='logging_provider:=sqlite3'
 fi
 
-ros2 launch deepracer_launcher deepracer_launcher.py ${INFERENCE_ENGINE} ${INFERENCE_DEVICE} ${BATTERY_DUMMY} ${LOGGING_MODE} ${LOGGING_PROVIDER}
+ros2 launch deepracer_launcher deepracer_launcher.py ${INFERENCE_ENGINE} ${INFERENCE_DEVICE} ${BATTERY_DUMMY} ${LOGGING_MODE} ${LOGGING_PROVIDER} ${CAMERA_MODE}

--- a/build_scripts/patches/aws-deepracer-ctrl-pkg.patch
+++ b/build_scripts/patches/aws-deepracer-ctrl-pkg.patch
@@ -83,19 +83,38 @@ index b82b35e..eb78cfb 100644
 \ No newline at end of file
 +#endif
 diff --git a/ctrl_pkg/src/ctrl_node.cpp b/ctrl_pkg/src/ctrl_node.cpp
-index 78aabe4..a17dae5 100644
+index 78aabe4..86fdfd9 100644
 --- a/ctrl_pkg/src/ctrl_node.cpp
 +++ b/ctrl_pkg/src/ctrl_node.cpp
-@@ -68,7 +68,7 @@ namespace SysCtrl {
+@@ -45,6 +45,11 @@ namespace SysCtrl {
+         numStates
+     };
+ 
++    enum CameraMode {
++        CAMERA_LEGACY_MODE,
++        CAMERA_MODERN_MODE
++    };
++
+     const char* VEHICLE_STATE_SRV = "vehicle_state";
+     const char* ENABLE_STATE_SRV = "enable_state";
+     const char* MODEL_STATE_SRV = "model_state";
+@@ -67,8 +72,13 @@ namespace SysCtrl {
+         : Node(nodeName), initialized_(false)
          {
              RCLCPP_INFO(this->get_logger(), "%s started", nodeName.c_str());
- 
+-
 -            vehicleCtrlModesServiceCbGrp_ = this->create_callback_group(rclcpp::callback_group::CallbackGroupType::Reentrant);
++            this->declare_parameter<std::string>("camera_mode", "legacy");
++            std::string mode_param = this->get_parameter("camera_mode").as_string();
++            mode_ = (mode_param == "modern") ? CAMERA_MODERN_MODE : CAMERA_LEGACY_MODE;
++            if (mode_param != "legacy" && mode_param != "modern") {
++                RCLCPP_ERROR(this->get_logger(), "Invalid mode parameter value. Defaulting to legacy.");
++            }
 +            vehicleCtrlModesServiceCbGrp_ = this->create_callback_group(rclcpp::CallbackGroupType::Reentrant);
              getVehicleCtrlModesService_ = this->create_service<deepracer_interfaces_pkg::srv::GetCtrlModesSrv>(GET_CTRL_MODES_SRV,
                                                                                                                 std::bind(&SysCtrl::CtrlNodeMgr::getCtrlModesHdl,
                                                                                                                 this,
-@@ -78,7 +78,7 @@ namespace SysCtrl {
+@@ -78,7 +88,7 @@ namespace SysCtrl {
                                                                                                                 ::rmw_qos_profile_default,
                                                                                                                 vehicleCtrlModesServiceCbGrp_);
  
@@ -104,7 +123,7 @@ index 78aabe4..a17dae5 100644
              setVehicleModeService_ = this->create_service<deepracer_interfaces_pkg::srv::ActiveStateSrv>(VEHICLE_STATE_SRV,
                                                                                                           std::bind(&SysCtrl::CtrlNodeMgr::stateHdl,
                                                                                                           this,
-@@ -87,7 +87,7 @@ namespace SysCtrl {
+@@ -87,7 +97,7 @@ namespace SysCtrl {
                                                                                                           std::placeholders::_3),
                                                                                                           ::rmw_qos_profile_default,
                                                                                                           vehicleModeServiceCbGrp_);
@@ -113,7 +132,7 @@ index 78aabe4..a17dae5 100644
              activateVehicleService_ = this->create_service<deepracer_interfaces_pkg::srv::EnableStateSrv>(ENABLE_STATE_SRV,
                                                                                                            std::bind(&SysCtrl::CtrlNodeMgr::ctrlStateHdl,
                                                                                                            this,
-@@ -98,7 +98,7 @@ namespace SysCtrl {
+@@ -98,7 +108,7 @@ namespace SysCtrl {
                                                                                                            activateVehicleServiceCbGrp_);
  
  
@@ -122,7 +141,7 @@ index 78aabe4..a17dae5 100644
              loadModelService_ = this->create_service<deepracer_interfaces_pkg::srv::ModelStateSrv>(MODEL_STATE_SRV,
                                                                                                      std::bind(&SysCtrl::CtrlNodeMgr::loadModelHdl,
                                                                                                      this,
-@@ -107,7 +107,7 @@ namespace SysCtrl {
+@@ -107,7 +117,7 @@ namespace SysCtrl {
                                                                                                      std::placeholders::_3),
                                                                                                      ::rmw_qos_profile_default,
                                                                                                      loadModelCbGrp_);
@@ -131,7 +150,7 @@ index 78aabe4..a17dae5 100644
              isModelLoadingService_ = this->create_service<deepracer_interfaces_pkg::srv::GetModelLoadingStatusSrv>(IS_MODEL_LOADING_SRV,
                                                                                                                      std::bind(&SysCtrl::CtrlNodeMgr::isModelLoadingHdl,
                                                                                                                      this,
-@@ -116,7 +116,7 @@ namespace SysCtrl {
+@@ -116,7 +126,7 @@ namespace SysCtrl {
                                                                                                                      std::placeholders::_3),
                                                                                                                      ::rmw_qos_profile_default,
                                                                                                                      isModelLoadingCbGrp_);
@@ -140,7 +159,7 @@ index 78aabe4..a17dae5 100644
              getCarCalibrationService_ = this->create_service<deepracer_interfaces_pkg::srv::GetCalibrationSrv>(GET_CAL_SRV,
                                                                                                                 std::bind(&SysCtrl::CtrlNodeMgr::getCarCalHdl,
                                                                                                                 this,
-@@ -134,7 +134,7 @@ namespace SysCtrl {
+@@ -134,7 +144,7 @@ namespace SysCtrl {
                                                                                                                 ::rmw_qos_profile_default,
                                                                                                                 vehicleCalibrationCbGrp_);
  
@@ -149,7 +168,7 @@ index 78aabe4..a17dae5 100644
              getCarLedService_ = this->create_service<deepracer_interfaces_pkg::srv::GetLedCtrlSrv>(GET_LED_SRV,
                                                                                                     std::bind(&SysCtrl::CtrlNodeMgr::getCarLedHdl,
                                                                                                     this,
-@@ -152,7 +152,7 @@ namespace SysCtrl {
+@@ -152,7 +162,7 @@ namespace SysCtrl {
                                                                                                      ::rmw_qos_profile_default,
                                                                                                      vehicleLedCbGrp_);
  
@@ -158,7 +177,20 @@ index 78aabe4..a17dae5 100644
              setAutonomousThrottleService_ = this->create_service<deepracer_interfaces_pkg::srv::NavThrottleSrv>(AUTONOMOUS_THROTTLE_SRV,
                                                                                                                  std::bind(&SysCtrl::CtrlNodeMgr::autoThrottleHdl,
                                                                                                                  this,
-@@ -205,7 +205,8 @@ namespace SysCtrl {
+@@ -174,8 +184,10 @@ namespace SysCtrl {
+                 activeState_->second->setStateActive(true);
+                 initialized_ = true;
+                 timer_->cancel();
+-                waitForServices();
+-                enableVideo();
++                if (mode_ == CAMERA_LEGACY_MODE) {
++                    waitForServices();
++                    enableVideo();
++                }
+             }
+         }
+ 
+@@ -205,7 +217,8 @@ namespace SysCtrl {
                                                                                               videoClientCbGrp_);
              while (!videoClient_->wait_for_service(std::chrono::seconds(1))) {
                  if (!rclcpp::ok()) {
@@ -168,7 +200,7 @@ index 78aabe4..a17dae5 100644
                  }
                  RCLCPP_INFO(this->get_logger(), "Camera node not available, waiting again...");
              }
-@@ -262,7 +263,7 @@ namespace SysCtrl {
+@@ -262,7 +275,7 @@ namespace SysCtrl {
          void loadModelHdl(const std::shared_ptr<rmw_request_id_t> request_header,
                            std::shared_ptr<deepracer_interfaces_pkg::srv::ModelStateSrv::Request> req,
                            std::shared_ptr<deepracer_interfaces_pkg::srv::ModelStateSrv::Response> res) {
@@ -177,7 +209,7 @@ index 78aabe4..a17dae5 100644
              res->error = 1;
              if (activeState_ == stateList_.end()) {
                  RCLCPP_ERROR(this->get_logger(), "No active state");
-@@ -403,26 +404,26 @@ namespace SysCtrl {
+@@ -403,27 +416,28 @@ namespace SysCtrl {
          std::unordered_map<int, std::shared_ptr<CtrlStateBase>>::const_iterator activeState_;
  
          /// ROS callback group object to be passed to the videoClient_.
@@ -211,8 +243,10 @@ index 78aabe4..a17dae5 100644
 -        rclcpp::callback_group::CallbackGroup::SharedPtr autonomousThrottleCbGrp_;
 +        rclcpp::CallbackGroup::SharedPtr autonomousThrottleCbGrp_;
          rclcpp::Service<deepracer_interfaces_pkg::srv::NavThrottleSrv>::SharedPtr setAutonomousThrottleService_;
++        CameraMode mode_;
      };
  }
+ 
 diff --git a/ctrl_pkg/src/ctrl_state.cpp b/ctrl_pkg/src/ctrl_state.cpp
 index a75a58a..80fc12d 100644
 --- a/ctrl_pkg/src/ctrl_state.cpp

--- a/build_scripts/patches/aws-deepracer-sensor-fusion-pkg.rpi.patch
+++ b/build_scripts/patches/aws-deepracer-sensor-fusion-pkg.rpi.patch
@@ -1,8 +1,87 @@
 diff --git a/sensor_fusion_pkg/src/sensor_fusion_node.cpp b/sensor_fusion_pkg/src/sensor_fusion_node.cpp
-index 028191a..ad5430b 100644
+index 028191a..8a48582 100644
 --- a/sensor_fusion_pkg/src/sensor_fusion_node.cpp
 +++ b/sensor_fusion_pkg/src/sensor_fusion_node.cpp
-@@ -283,25 +283,40 @@ namespace SensorFusion {
+@@ -111,6 +111,11 @@ namespace SensorFusion {
+         numLidarPreprocessingType
+     };
+ 
++    enum CameraMode {
++        CAMERA_LEGACY_MODE,
++        CAMERA_MODERN_MODE
++    };
++
+     // Message Topics to publish to.
+     const char* SENSOR_MSG_TOPIC = "sensor_msg";
+     const char* OVERLAY_MSG_TOPIC = "overlay_msg";
+@@ -120,6 +125,7 @@ namespace SensorFusion {
+     // Message topics to subscribe to.
+     const char* CAMERA_MSG_TOPIC = "/camera_pkg/video_mjpeg";
+     const char* DISPLAY_MSG_TOPIC = "/camera_pkg/display_mjpeg";
++    const char* COMP_IMG_MSG_TOPIC = "/camera_pkg/display_mjpeg/compressed";
+     const char* LIDAR_MSG_TOPIC = "/rplidar_ros/scan";
+ 
+     // Sensor configuration file path.
+@@ -162,6 +168,12 @@ namespace SensorFusion {
+ 
+             RCLCPP_INFO(this->get_logger(), "%s started", node_name.c_str());
+             this->declare_parameter<std::string>("image_transport", "raw");
++            this->declare_parameter<std::string>("camera_mode", "legacy");
++            std::string mode_param = this->get_parameter("camera_mode").as_string();
++            mode_ = (mode_param == "modern") ? CAMERA_MODERN_MODE : CAMERA_LEGACY_MODE;
++            if (mode_param != "legacy" && mode_param != "modern") {
++                RCLCPP_ERROR(this->get_logger(), "Invalid mode parameter value. Defaulting to legacy.");
++            }
+             createDefaultSensorConfiguration();
+             if (checkFile(SENSOR_CONFIGURATION_FILE_PATH)) {
+                 setSensorConfigurationFromFile(sensorConfiguration_,
+@@ -212,16 +224,23 @@ namespace SensorFusion {
+                                                                                          this,
+                                                                                          std::placeholders::_1));
+             // Subscriber to subscribe to the camera sensor messages published by the camera_pkg.
+-            cameraSub_ = this->create_subscription<deepracer_interfaces_pkg::msg::CameraMsg>(CAMERA_MSG_TOPIC,
++            if (mode_ == CAMERA_LEGACY_MODE) {
++                cameraSub_ = this->create_subscription<deepracer_interfaces_pkg::msg::CameraMsg>(std::string(CAMERA_MSG_TOPIC),
++                                                                                                sensorMsgQOS,
++                                                                                                std::bind(&SensorFusionNode::cameraCB,
++                                                                                                          this,
++                                                                                                          std::placeholders::_1));
++            } else {
++                cameraModernSub_ = this->create_subscription<sensor_msgs::msg::CompressedImage>(std::string(COMP_IMG_MSG_TOPIC),
+                                                                                              sensorMsgQOS,
+-                                                                                             std::bind(&SensorFusionNode::cameraCB,
++                                                                                             std::bind(&SensorFusionNode::cameraModernCB,
+                                                                                                        this,
+                                                                                                        std::placeholders::_1));
+-
++            }
+             // Subscriber to subscribe to the camera display messages published by the camera_pkg.
+             image_transport::TransportHints ith(this);
+             RCLCPP_INFO(this->get_logger(), "image_transport configured to use %s", ith.getTransport().c_str());
+-            displaySub_ = image_transport_.subscribe<SensorFusionNode>(std::string(DISPLAY_MSG_TOPIC), 1, 
++            displaySub_ = image_transport_.subscribe<SensorFusionNode>(DISPLAY_MSG_TOPIC, 1, 
+                                                                        &SensorFusionNode::displayCB, 
+                                                                        node_handle_, &ith);
+ 
+@@ -279,29 +298,58 @@ namespace SensorFusion {
+             }
+         }
+ 
++
++        /// Callback function for camera message subscription.
++        /// @param msg Message with images from DeepRacer cameras.
++        void cameraModernCB(const sensor_msgs::msg::CompressedImage::ConstSharedPtr & msg) {
++            try {
++                auto camera_msg = std::make_shared<deepracer_interfaces_pkg::msg::CameraMsg>();
++                camera_msg->images.push_back(*msg);
++                cameraCB(camera_msg);
++            }
++            catch (const std::exception &ex) {
++                RCLCPP_ERROR(this->get_logger(), "Camera callback failed: %s", ex.what());
++            }
++        }
++
+         /// Callback function for camera message subscription.
          /// @param msg Message with images from DeepRacer cameras.
          void displayCB(const sensor_msgs::msg::Image::ConstSharedPtr & msg) {
              try {
@@ -59,7 +138,15 @@ index 028191a..ad5430b 100644
                  }
              }
              catch (const std::exception &ex) {
-@@ -560,8 +575,8 @@ namespace SensorFusion {
+@@ -537,6 +585,7 @@ namespace SensorFusion {
+         rclcpp::Subscription<sensor_msgs::msg::LaserScan>::SharedPtr lidarSub_;
+         rclcpp::Subscription<deepracer_interfaces_pkg::msg::CameraMsg>::SharedPtr cameraSub_;
+         image_transport::Subscriber displaySub_;
++        rclcpp::Subscription<sensor_msgs::msg::CompressedImage>::SharedPtr cameraModernSub_;
+ 
+         rclcpp::Service<deepracer_interfaces_pkg::srv::LidarConfigSrv>::SharedPtr lidarConfigService_;
+         rclcpp::Service<deepracer_interfaces_pkg::srv::SensorStatusCheckSrv>::SharedPtr statusCheckService_;
+@@ -560,9 +609,10 @@ namespace SensorFusion {
          std::chrono::steady_clock::time_point lastLidarMsgRecievedTime;
          std::chrono::steady_clock::time_point lastCameraMsgRecievedTime;
          size_t cameraImageCount_;
@@ -68,5 +155,7 @@ index 028191a..ad5430b 100644
 +        unsigned int imageWidth_;
 +        unsigned int imageHeight_;
          std::mutex lidarMutex_;
++        CameraMode mode_;
  
      };
+ }

--- a/build_scripts/versions.json
+++ b/build_scripts/versions.json
@@ -1,5 +1,5 @@
 {
-	"aws-deepracer-core": "2.1.2.6+community",
+	"aws-deepracer-core": "2.1.3.0+community",
 	"aws-deepracer-device-console": "2.0.196.3+community",
 	"aws-deepracer-sample-models": "2.0.9.0",
 	"aws-deepracer-util": "2.0.61.5+community"

--- a/install_scripts/rpi4-22.04/aws_deepracer-community.list
+++ b/install_scripts/rpi4-22.04/aws_deepracer-community.list
@@ -1,2 +1,2 @@
 deb [arch=arm64 signed-by=CFB167A8F18DE6A634A6A2E4A63BC335D48DF8C6] https://aws-deepracer-community-sw.s3.eu-west-1.amazonaws.com/deepracer-custom-car stable rpi4-jammy
-# deb [arch=arm64 signed-by=CFB167A8F18DE6A634A6A2E4A63BC335D48DF8C6] https://aws-deepracer-community-sw.s3.eu-west-1.amazonaws.com/deepracer-custom-car experimental rpi4-jammy
+deb [arch=arm64 signed-by=CFB167A8F18DE6A634A6A2E4A63BC335D48DF8C6] https://aws-deepracer-community-sw.s3.eu-west-1.amazonaws.com/deepracer-custom-car experimental rpi4-jammy

--- a/install_scripts/rpi4-22.04/install-deepracer.sh
+++ b/install_scripts/rpi4-22.04/install-deepracer.sh
@@ -55,7 +55,7 @@ apt -y update && apt install -y --no-install-recommends \
 rosdep init && rosdep update --rosdistro=humble -q
 
 # Update build tools and utilities for Python
-pip3 install -U "setuptools<50" pip "cython<3" "wheel==0.42.0" testresources
+sudo pip3 install -U "setuptools==58.2.0" pip "Cython==0.29.28" testresources
 
 # Get OpenVINO
 mkdir -p $DIR/dist/

--- a/install_scripts/rpi4-22.04/install-prerequisites.sh
+++ b/install_scripts/rpi4-22.04/install-prerequisites.sh
@@ -62,7 +62,7 @@ ufw allow "OpenSSH"
 ufw enable
 
 # Install other tools / configure network management
-apt -y --no-install-recommends install curl network-manager wireless-tools net-tools i2c-tools v4l-utils libraspberrypi-bin raspi-config 
+apt -y --no-install-recommends install curl network-manager wireless-tools net-tools i2c-tools v4l-utils libraspberrypi-bin
 cp $DIR/build_scripts/files/pi/10-manage-wifi.conf /etc/NetworkManager/conf.d/
 systemctl disable systemd-networkd-wait-online
 

--- a/install_scripts/rpi4-22.04/install-prerequisites.sh
+++ b/install_scripts/rpi4-22.04/install-prerequisites.sh
@@ -69,7 +69,6 @@ systemctl disable systemd-networkd-wait-online
 sed -i 's/wifi.powersave = 3/wifi.powersave = 2/' /etc/NetworkManager/conf.d/default-wifi-powersave-on.conf
 sed -i 's/renderer: networkd/renderer: NetworkManager/' /etc/netplan/50-cloud-init.yaml
 echo -e "\nRestarting the network stack. This might require reconnection. Pi might receive a new IP address."
-echo -e "If using Raspberry Pi Camera please run raspi-config and enable legacy camera support.\n"
 echo -e "After script has finished, reboot.\n"
 systemctl restart NetworkManager
 netplan apply

--- a/install_scripts/rpi4-22.04/rc.local
+++ b/install_scripts/rpi4-22.04/rc.local
@@ -1,8 +1,5 @@
 #!/usr/bin/env bash
 
-# PiCam is mounted upside down
-v4l2-ctl --set-ctrl=rotate=180
-
 # Fan is on pwm5
 echo 5 > /sys/class/pwm/pwmchip0/export
 PERIOD=20000000


### PR DESCRIPTION
This branch provides support for using libcamera on the Raspberry Pi, removing the need to rely on the legacy camera stack, which caused issues on the Compute Module 4, and which is preventing use of Ubuntu 24.04 in the future where the legacy camera stack is no longer available.