### PR TITLE
USB Creation: Add ability to use custom URL

### DIFF
--- a/utils/custom_image/ INSTRUCTIONS.md
+++ b/utils/custom_image/ INSTRUCTIONS.md
@@ -1,4 +1,13 @@
-# To create a USB flash drive with the custom image:
+# Custom Image USB Flash Drive Creation
+
+## Create a USB flash drive automatically with the custom image
+
+* Enter the utils directory
+* Run `./usb-build.ubuntu.sh -d [drive] -r https://larsll-build-artifact-share.s3.eu-north-1.amazonaws.com/car-image/custom_factory_reset.zip`
+* Drive is `sdb`, `sdc` or similar. Use `lsblk` to look for the available drives.
+
+
+## Create a USB flash drive manually with the custom image
 
 * Create the USB drive as normal with one of the usb-build scripts in `utils/`.
 * Insert it into a PC - identify the "FLASH" partition (3rd partition on the drive)


### PR DESCRIPTION
This pull request introduces enhancements to the `utils/usb-build.ubuntu.sh` script and its documentation to support a custom factory reset URL and improve usability. Key changes include adding a new optional parameter for the custom reset URL, updating the download logic to handle custom file names, and improving the instructions for creating a USB flash drive.

### Documentation Updates:
* [`utils/custom_image/INSTRUCTIONS.md`](diffhunk://#diff-201aef7fbca4af024775e96c612715a1c84195407f7ef502c94782ad36d27308L1-R10): Updated the instructions to include an automatic method for creating a USB flash drive with a custom image, alongside the existing manual method.

### Script Enhancements:
1. **Support for Custom Factory Reset URL**:
   * Added a new `-r` parameter to specify a custom reset URL. This is reflected in the usage instructions (`show_usage`) and the argument parsing logic. [[1]](diffhunk://#diff-09f05489d68a9f706848e4f65f29c08712cf688ad3e7f4094af9992731e34a36L118-R132) [[2]](diffhunk://#diff-09f05489d68a9f706848e4f65f29c08712cf688ad3e7f4094af9992731e34a36L452-R474)
   * Modified the `get_factory_reset()` function to use the custom reset URL if provided, defaulting to the existing URL otherwise. The downloaded file is saved as `factory_reset.zip`.

2. **Improved File Download Logic**:
   * Updated the `donwload_file()` function to allow specifying a custom output file name while maintaining backward compatibility.

3. **Process Automation**:
   * Enhanced the `process_all()` function to pass the custom reset URL parameter (`-r`) to subprocesses when provided. 

These changes improve flexibility, streamline the USB creation process, and provide clearer guidance for users.