### PR TITLE
Fix compatibility for Compute Modules

### DIFF
--- a/src/aws-deepracer-device-info-pkg/device_info_pkg/device_info_pkg/constants.py
+++ b/src/aws-deepracer-device-info-pkg/device_info_pkg/device_info_pkg/constants.py
@@ -63,10 +63,13 @@ def get_system_type():
     """
     if os.path.exists("/sys/class/dmi/id/chassis_serial"):
         return SystemType.DR
-    elif os.path.exists("/proc/device-tree/model") and "Raspberry Pi 4" in open("/proc/device-tree/model").read():
-        return SystemType.RPI4
-    elif os.path.exists("/proc/device-tree/model") and "Raspberry Pi 5" in open("/proc/device-tree/model").read():
-        return SystemType.RPI5
+    elif os.path.exists("/proc/device-tree/model"):
+        with open("/proc/device-tree/model") as f:
+            model = f.read()
+        if any(x in model for x in ["Raspberry Pi 4", "Raspberry Pi Compute Module 4"]):
+            return SystemType.RPI4
+        elif any(x in model for x in ["Raspberry Pi 5", "Raspberry Pi Compute Module 5"]):
+            return SystemType.RPI5
 
 
 SYSTEM_TYPE = get_system_type()

--- a/src/aws-deepracer-status-led-pkg/status_led_pkg/status_led_pkg/constants.py
+++ b/src/aws-deepracer-status-led-pkg/status_led_pkg/status_led_pkg/constants.py
@@ -35,10 +35,13 @@ def get_system_type():
     """
     if os.path.exists("/sys/class/dmi/id/chassis_serial"):
         return SystemType.DR
-    elif os.path.exists("/proc/device-tree/model") and "Raspberry Pi 4" in open("/proc/device-tree/model").read():
-        return SystemType.RPI4
-    elif os.path.exists("/proc/device-tree/model") and "Raspberry Pi 5" in open("/proc/device-tree/model").read():
-        return SystemType.RPI5
+    elif os.path.exists("/proc/device-tree/model"):
+        with open("/proc/device-tree/model") as f:
+            model = f.read()
+        if any(x in model for x in ["Raspberry Pi 4", "Raspberry Pi Compute Module 4"]):
+            return SystemType.RPI4
+        elif any(x in model for x in ["Raspberry Pi 5", "Raspberry Pi Compute Module 5"]):
+            return SystemType.RPI5
 
 SYSTEM_TYPE = get_system_type()
 

--- a/versions.json
+++ b/versions.json
@@ -1,5 +1,5 @@
 {
-	"aws-deepracer-core": "2.1.8.8+community",
+	"aws-deepracer-core": "2.1.8.8+community1",
 	"aws-deepracer-device-console": "2.0.196.3+community",
 	"aws-deepracer-sample-models": "2.0.9.0",
 	"aws-deepracer-util": "2.1.0.8+community",


### PR DESCRIPTION
This pull request enhances the detection logic for system types and updates a version identifier in the `versions.json` file. The most important changes include improving the `get_system_type` function to support additional Raspberry Pi models and updating the version string for the `aws-deepracer-core` package.

### System Type Detection Improvements:
* [`src/aws-deepracer-device-info-pkg/device_info_pkg/device_info_pkg/constants.py`](diffhunk://#diff-c0b0646ef7c736dad59de66ecbe7eb515174e2b9f7fed7cd9172b4cfc5f48af6L66-R71): Updated the `get_system_type` function to use a more efficient approach for reading and checking `/proc/device-tree/model`. It now supports detecting "Raspberry Pi Compute Module 4" and "Raspberry Pi Compute Module 5" in addition to "Raspberry Pi 4" and "Raspberry Pi 5".
* [`src/aws-deepracer-status-led-pkg/status_led_pkg/status_led_pkg/constants.py`](diffhunk://#diff-90174544a41fff858bbaccbe9a5c970a1ab52e1cad0edc3ff5568ab426e21713L38-R43): Applied the same improvements to the `get_system_type` function, ensuring consistent behavior across modules.

### Version Update:
* [`versions.json`](diffhunk://#diff-2b39d33506bc7a34cef4b9ebf4cf8b1e3a5532f2131ceb37011b94261cec5f8cL2-R2): Updated the `aws-deepracer-core` version from `2.1.8.8+community` to `2.1.8.8+community1`.